### PR TITLE
added service package

### DIFF
--- a/service/error.go
+++ b/service/error.go
@@ -1,0 +1,30 @@
+package service
+
+import (
+	"fmt"
+
+	"github.com/juju/errgo"
+)
+
+var (
+	maskAny = errgo.MaskFunc(errgo.Any)
+)
+
+func maskAnyf(err error, f string, v ...interface{}) error {
+	if err == nil {
+		return nil
+	}
+
+	f = fmt.Sprintf("%s: %s", err.Error(), f)
+	newErr := errgo.WithCausef(nil, errgo.Cause(err), f, v...)
+	newErr.(*errgo.Err).SetLocation(1)
+
+	return newErr
+}
+
+var invalidConfigError = errgo.New("invalid config")
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return errgo.Cause(err) == invalidConfigError
+}

--- a/service/service.go
+++ b/service/service.go
@@ -1,0 +1,71 @@
+// Package service implements business logic of the micro service.
+package service
+
+import (
+	kitlog "github.com/go-kit/kit/log"
+
+	"github.com/giantswarm/microkit-example/service/version"
+)
+
+// Config represents the configuration used to create a new service.
+type Config struct {
+	// Dependencies.
+	Logger kitlog.Logger
+
+	// Settings.
+	Description    string
+	GitCommit      string
+	Name           string
+	ProjectVersion string
+	Source         string
+}
+
+// DefaultConfig provides a default configuration to create a new service by
+// best effort.
+func DefaultConfig() Config {
+	return Config{
+		// Dependencies.
+		Logger: nil,
+
+		// Settings.
+		Description:    "",
+		GitCommit:      "",
+		Name:           "",
+		ProjectVersion: "",
+		Source:         "",
+	}
+}
+
+// New creates a new configured service object.
+func New(config Config) (*Service, error) {
+	var err error
+
+	var versionService *version.Service
+	{
+		versionConfig := version.DefaultConfig()
+
+		versionConfig.Logger = config.Logger
+
+		versionConfig.Description = config.Description
+		versionConfig.GitCommit = config.GitCommit
+		versionConfig.Name = config.Name
+		versionConfig.ProjectVersion = config.ProjectVersion
+		versionConfig.Source = config.Source
+
+		versionService, err = version.New(versionConfig)
+		if err != nil {
+			return nil, maskAny(err)
+		}
+	}
+
+	newService := &Service{
+		Version: versionService,
+	}
+
+	return newService, nil
+}
+
+// Service bundles other services.
+type Service struct {
+	Version *version.Service
+}

--- a/service/version/error.go
+++ b/service/version/error.go
@@ -1,0 +1,30 @@
+package version
+
+import (
+	"fmt"
+
+	"github.com/juju/errgo"
+)
+
+var (
+	maskAny = errgo.MaskFunc(errgo.Any)
+)
+
+func maskAnyf(err error, f string, v ...interface{}) error {
+	if err == nil {
+		return nil
+	}
+
+	f = fmt.Sprintf("%s: %s", err.Error(), f)
+	newErr := errgo.WithCausef(nil, errgo.Cause(err), f, v...)
+	newErr.(*errgo.Err).SetLocation(1)
+
+	return newErr
+}
+
+var invalidConfigError = errgo.New("invalid config")
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return errgo.Cause(err) == invalidConfigError
+}

--- a/service/version/request.go
+++ b/service/version/request.go
@@ -1,0 +1,10 @@
+package version
+
+// Request is the configuration for the service action.
+type Request struct {
+}
+
+// DefaultRequest provides a default request object by best effort.
+func DefaultRequest() Request {
+	return Request{}
+}

--- a/service/version/response.go
+++ b/service/version/response.go
@@ -1,0 +1,25 @@
+package version
+
+// Response is the return value of the service action.
+type Response struct {
+	Description    string `json:"description"`
+	GitCommit      string `json:"git_commit"`
+	GoVersion      string `json:"go_version"`
+	Name           string `json:"name"`
+	OSArch         string `json:"os_arch"`
+	ProjectVersion string `json:"project_version"`
+	Source         string `json:"source"`
+}
+
+// DefaultResponse provides a default response object by best effort.
+func DefaultResponse() *Response {
+	return &Response{
+		Description:    "",
+		GitCommit:      "",
+		GoVersion:      "",
+		Name:           "",
+		OSArch:         "",
+		ProjectVersion: "",
+		Source:         "",
+	}
+}

--- a/service/version/service.go
+++ b/service/version/service.go
@@ -1,0 +1,92 @@
+package version
+
+import (
+	"runtime"
+
+	micrologger "github.com/giantswarm/microkit/logger"
+)
+
+// Config represents the configuration used to create a version service.
+type Config struct {
+	// Dependencies.
+	Logger micrologger.Logger
+
+	// Settings.
+	Description    string
+	GitCommit      string
+	Name           string
+	ProjectVersion string
+	Source         string
+}
+
+// DefaultConfig provides a default configuration to create a new version service
+// by best effort.
+func DefaultConfig() Config {
+	return Config{
+		// Dependencies.
+		Logger: nil,
+
+		// Settings.
+		Description:    "",
+		GitCommit:      "",
+		Name:           "",
+		ProjectVersion: "",
+		Source:         "",
+	}
+}
+
+// New creates a new configured version service.
+func New(config Config) (*Service, error) {
+	// Dependencies.
+	if config.Logger == nil {
+		return nil, maskAnyf(invalidConfigError, "logger must not be empty")
+	}
+
+	// Settings.
+	if config.Description == "" {
+		return nil, maskAnyf(invalidConfigError, "description commit must not be empty")
+	}
+	if config.GitCommit == "" {
+		return nil, maskAnyf(invalidConfigError, "git commit must not be empty")
+	}
+	if config.Name == "" {
+		return nil, maskAnyf(invalidConfigError, "name must not be empty")
+	}
+	if config.ProjectVersion == "" {
+		return nil, maskAnyf(invalidConfigError, "project version must not be empty")
+	}
+	if config.Source == "" {
+		return nil, maskAnyf(invalidConfigError, "name must not be empty")
+	}
+
+	newService := &Service{
+		Config: config,
+
+		GoVersion: runtime.Version(),
+	}
+
+	return newService, nil
+}
+
+// Service implements the version service interface.
+type Service struct {
+	Config
+
+	GoVersion string
+}
+
+func (s *Service) Get(request Request) (*Response, error) {
+	s.Logger.Log("func", "Get")
+
+	response := DefaultResponse()
+
+	response.Description = s.Description
+	response.GitCommit = s.GitCommit
+	response.GoVersion = runtime.Version()
+	response.Name = s.Name
+	response.OSArch = runtime.GOOS + "/" + runtime.GOARCH
+	response.ProjectVersion = s.ProjectVersion
+	response.Source = s.Source
+
+	return response, nil
+}


### PR DESCRIPTION
This PR adds the service package of the microkit-example. It implements an example version service  which is registered using its corresponding endpoint. This is basically the same as in our microservice-blueprint. Currently the build fails because I separated PRs to not have one giant PR. 