### PR TITLE
removed project version support

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -19,4 +19,4 @@ dependencies:
 test:
     override:
         - cd $GS_WD && go test -v $(glide novendor)
-        - cd $GS_WD && go build -a -v -tags netgo -ldflags "-w -X main.gitCommit=$(git rev-parse --short HEAD) -X main.projectVersion=$(cat VERSION)"
+        - cd $GS_WD && go build -a -v -tags netgo -ldflags "-w -X main.gitCommit=$(git rev-parse --short HEAD)"

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 02b6295037e9fbf33c776dceb1ea0dbfcc22fb048e5b24e3705cd826feab7c64
-updated: 2016-12-17T23:01:16.27983464+01:00
+updated: 2016-12-20T12:53:44.741854022+01:00
 imports:
 - name: github.com/beorn7/perks
   version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
@@ -8,7 +8,7 @@ imports:
 - name: github.com/fsnotify/fsnotify
   version: fd9ec7deca8bf46ecd2a795baaacf2b3a9be1197
 - name: github.com/giantswarm/microkit
-  version: 91fa23ed8924b84c4ea447e1cdc1dcf7bf5f5f42
+  version: 93622d2b9d5456ab3d070ef6719c88b390eac8b2
   subpackages:
   - command
   - command/daemon
@@ -73,7 +73,7 @@ imports:
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: 195bde7883f7c39ea62b0d92ab7359b5327065cb
+  version: ad540c5ab198ab0c5172f5c6b602a49ab911b5ef
   subpackages:
   - expfmt
   - internal/bitbucket.org/ww/goautoneg
@@ -91,7 +91,7 @@ imports:
 - name: github.com/spf13/jwalterweatherman
   version: 33c24e77fb80341fe7130ee7c594256ff08ccc46
 - name: github.com/spf13/pflag
-  version: c7e63cf4530bcd3ba943729cee0efeff2ebea63f
+  version: 5ccb023bc27df288a957c5e994cd44fd19619465
 - name: github.com/spf13/viper
   version: 5ed0fc31f7f453625df314d8e66b9791e8d13003
 - name: github.com/tylerb/graceful

--- a/main.go
+++ b/main.go
@@ -12,11 +12,10 @@ import (
 )
 
 var (
-	description    string = "This is an example microservice using the microkit framework."
-	gitCommit      string = "n/a"
-	name           string = "microkit-example"
-	projectVersion string = "n/a"
-	source         string = "https://github.com/giantswarm/microkit-example"
+	description string = "This is an example microservice using the microkit framework."
+	gitCommit   string = "n/a"
+	name        string = "microkit-example"
+	source      string = "https://github.com/giantswarm/microkit-example"
 )
 
 func main() {
@@ -46,7 +45,6 @@ func main() {
 			serviceConfig.Description = description
 			serviceConfig.GitCommit = gitCommit
 			serviceConfig.Name = name
-			serviceConfig.ProjectVersion = projectVersion
 			serviceConfig.Source = source
 
 			newService, err = service.New(serviceConfig)
@@ -83,7 +81,6 @@ func main() {
 		commandConfig.Description = description
 		commandConfig.GitCommit = gitCommit
 		commandConfig.Name = name
-		commandConfig.ProjectVersion = projectVersion
 		commandConfig.Source = source
 
 		newCommand, err = command.New(commandConfig)

--- a/server/endpoint/version/endpoint.go
+++ b/server/endpoint/version/endpoint.go
@@ -93,7 +93,6 @@ func (e *Endpoint) Endpoint() kitendpoint.Endpoint {
 		response.GoVersion = serviceResponse.GoVersion
 		response.Name = serviceResponse.Name
 		response.OSArch = serviceResponse.OSArch
-		response.ProjectVersion = serviceResponse.ProjectVersion
 		response.Source = serviceResponse.Source
 
 		return response, nil

--- a/server/endpoint/version/response.go
+++ b/server/endpoint/version/response.go
@@ -2,24 +2,22 @@ package version
 
 // Response is the return value of the service action.
 type Response struct {
-	Description    string `json:"description"`
-	GitCommit      string `json:"git_commit"`
-	GoVersion      string `json:"go_version"`
-	Name           string `json:"name"`
-	OSArch         string `json:"os_arch"`
-	ProjectVersion string `json:"project_version"`
-	Source         string `json:"source"`
+	Description string `json:"description"`
+	GitCommit   string `json:"git_commit"`
+	GoVersion   string `json:"go_version"`
+	Name        string `json:"name"`
+	OSArch      string `json:"os_arch"`
+	Source      string `json:"source"`
 }
 
 // DefaultResponse provides a default response object by best effort.
 func DefaultResponse() *Response {
 	return &Response{
-		Description:    "",
-		GitCommit:      "",
-		GoVersion:      "",
-		Name:           "",
-		OSArch:         "",
-		ProjectVersion: "",
-		Source:         "",
+		Description: "",
+		GitCommit:   "",
+		GoVersion:   "",
+		Name:        "",
+		OSArch:      "",
+		Source:      "",
 	}
 }

--- a/server/middleware/version/middleware.go
+++ b/server/middleware/version/middleware.go
@@ -48,10 +48,8 @@ type Middleware struct {
 
 func (m *Middleware) Middleware(next kitendpoint.Endpoint) kitendpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
-		m.Logger.Log(
-			"msg", "version middleware was called",
-			"fixme", "I do useless shit",
-		)
+
+		// Your middleware logic goes here.
 
 		return next(ctx, request)
 	}

--- a/service/service.go
+++ b/service/service.go
@@ -13,11 +13,10 @@ type Config struct {
 	Logger kitlog.Logger
 
 	// Settings.
-	Description    string
-	GitCommit      string
-	Name           string
-	ProjectVersion string
-	Source         string
+	Description string
+	GitCommit   string
+	Name        string
+	Source      string
 }
 
 // DefaultConfig provides a default configuration to create a new service by
@@ -28,11 +27,10 @@ func DefaultConfig() Config {
 		Logger: nil,
 
 		// Settings.
-		Description:    "",
-		GitCommit:      "",
-		Name:           "",
-		ProjectVersion: "",
-		Source:         "",
+		Description: "",
+		GitCommit:   "",
+		Name:        "",
+		Source:      "",
 	}
 }
 
@@ -49,7 +47,6 @@ func New(config Config) (*Service, error) {
 		versionConfig.Description = config.Description
 		versionConfig.GitCommit = config.GitCommit
 		versionConfig.Name = config.Name
-		versionConfig.ProjectVersion = config.ProjectVersion
 		versionConfig.Source = config.Source
 
 		versionService, err = version.New(versionConfig)

--- a/service/version/response.go
+++ b/service/version/response.go
@@ -2,24 +2,22 @@ package version
 
 // Response is the return value of the service action.
 type Response struct {
-	Description    string `json:"description"`
-	GitCommit      string `json:"git_commit"`
-	GoVersion      string `json:"go_version"`
-	Name           string `json:"name"`
-	OSArch         string `json:"os_arch"`
-	ProjectVersion string `json:"project_version"`
-	Source         string `json:"source"`
+	Description string `json:"description"`
+	GitCommit   string `json:"git_commit"`
+	GoVersion   string `json:"go_version"`
+	Name        string `json:"name"`
+	OSArch      string `json:"os_arch"`
+	Source      string `json:"source"`
 }
 
 // DefaultResponse provides a default response object by best effort.
 func DefaultResponse() *Response {
 	return &Response{
-		Description:    "",
-		GitCommit:      "",
-		GoVersion:      "",
-		Name:           "",
-		OSArch:         "",
-		ProjectVersion: "",
-		Source:         "",
+		Description: "",
+		GitCommit:   "",
+		GoVersion:   "",
+		Name:        "",
+		OSArch:      "",
+		Source:      "",
 	}
 }

--- a/service/version/service.go
+++ b/service/version/service.go
@@ -12,11 +12,10 @@ type Config struct {
 	Logger micrologger.Logger
 
 	// Settings.
-	Description    string
-	GitCommit      string
-	Name           string
-	ProjectVersion string
-	Source         string
+	Description string
+	GitCommit   string
+	Name        string
+	Source      string
 }
 
 // DefaultConfig provides a default configuration to create a new version service
@@ -27,11 +26,10 @@ func DefaultConfig() Config {
 		Logger: nil,
 
 		// Settings.
-		Description:    "",
-		GitCommit:      "",
-		Name:           "",
-		ProjectVersion: "",
-		Source:         "",
+		Description: "",
+		GitCommit:   "",
+		Name:        "",
+		Source:      "",
 	}
 }
 
@@ -51,9 +49,6 @@ func New(config Config) (*Service, error) {
 	}
 	if config.Name == "" {
 		return nil, maskAnyf(invalidConfigError, "name must not be empty")
-	}
-	if config.ProjectVersion == "" {
-		return nil, maskAnyf(invalidConfigError, "project version must not be empty")
 	}
 	if config.Source == "" {
 		return nil, maskAnyf(invalidConfigError, "name must not be empty")
@@ -76,8 +71,6 @@ type Service struct {
 }
 
 func (s *Service) Get(request Request) (*Response, error) {
-	s.Logger.Log("func", "Get")
-
 	response := DefaultResponse()
 
 	response.Description = s.Description
@@ -85,7 +78,6 @@ func (s *Service) Get(request Request) (*Response, error) {
 	response.GoVersion = runtime.Version()
 	response.Name = s.Name
 	response.OSArch = runtime.GOOS + "/" + runtime.GOARCH
-	response.ProjectVersion = s.ProjectVersion
 	response.Source = s.Source
 
 	return response, nil

--- a/vendor/github.com/giantswarm/microkit/command/command.go
+++ b/vendor/github.com/giantswarm/microkit/command/command.go
@@ -18,11 +18,10 @@ type Config struct {
 	ServerFactory func() server.Server
 
 	// Settings.
-	Description    string
-	GitCommit      string
-	Name           string
-	ProjectVersion string
-	Source         string
+	Description string
+	GitCommit   string
+	Name        string
+	Source      string
 }
 
 // DefaultConfig provides a default configuration to create a new root command
@@ -34,11 +33,10 @@ func DefaultConfig() Config {
 		ServerFactory: nil,
 
 		// Settings.
-		Description:    "",
-		GitCommit:      "",
-		Name:           "",
-		ProjectVersion: "",
-		Source:         "",
+		Description: "",
+		GitCommit:   "",
+		Name:        "",
+		Source:      "",
 	}
 }
 
@@ -66,7 +64,6 @@ func New(config Config) (Command, error) {
 		versionConfig.Description = config.Description
 		versionConfig.GitCommit = config.GitCommit
 		versionConfig.Name = config.Name
-		versionConfig.ProjectVersion = config.ProjectVersion
 		versionConfig.Source = config.Source
 
 		versionCommand, err = version.New(versionConfig)

--- a/vendor/github.com/giantswarm/microkit/command/version/command.go
+++ b/vendor/github.com/giantswarm/microkit/command/version/command.go
@@ -13,11 +13,10 @@ import (
 // Config represents the configuration used to create a new version command.
 type Config struct {
 	// Settings.
-	Description    string
-	GitCommit      string
-	Name           string
-	ProjectVersion string
-	Source         string
+	Description string
+	GitCommit   string
+	Name        string
+	Source      string
 }
 
 // DefaultConfig provides a default configuration to create a new version
@@ -25,11 +24,10 @@ type Config struct {
 func DefaultConfig() Config {
 	return Config{
 		// Settings.
-		Description:    "",
-		GitCommit:      "",
-		Name:           "",
-		ProjectVersion: "",
-		Source:         "",
+		Description: "",
+		GitCommit:   "",
+		Name:        "",
+		Source:      "",
 	}
 }
 
@@ -45,9 +43,6 @@ func New(config Config) (Command, error) {
 	if config.Name == "" {
 		return nil, microerror.MaskAnyf(invalidConfigError, "name must not be empty")
 	}
-	if config.ProjectVersion == "" {
-		return nil, microerror.MaskAnyf(invalidConfigError, "project version must not be empty")
-	}
 	if config.Source == "" {
 		return nil, microerror.MaskAnyf(invalidConfigError, "name must not be empty")
 	}
@@ -57,11 +52,10 @@ func New(config Config) (Command, error) {
 		cobraCommand: nil,
 
 		// Settings.
-		description:    config.Description,
-		gitCommit:      config.GitCommit,
-		name:           config.Name,
-		projectVersion: config.ProjectVersion,
-		source:         config.Source,
+		description: config.Description,
+		gitCommit:   config.GitCommit,
+		name:        config.Name,
+		source:      config.Source,
 	}
 
 	newCommand.cobraCommand = &cobra.Command{
@@ -79,11 +73,10 @@ type command struct {
 	cobraCommand *cobra.Command
 
 	// Settings.
-	description    string
-	gitCommit      string
-	name           string
-	projectVersion string
-	source         string
+	description string
+	gitCommit   string
+	name        string
+	source      string
 }
 
 func (c *command) CobraCommand() *cobra.Command {
@@ -91,11 +84,10 @@ func (c *command) CobraCommand() *cobra.Command {
 }
 
 func (c *command) Execute(cmd *cobra.Command, args []string) {
-	fmt.Printf("Description:        %s\n", c.description)
-	fmt.Printf("Git Commit:         %s\n", c.gitCommit)
-	fmt.Printf("Go Version:         %s\n", runtime.Version())
-	fmt.Printf("Name:               %s\n", c.name)
-	fmt.Printf("OS / Arch:          %s / %s\n", runtime.GOOS, runtime.GOARCH)
-	fmt.Printf("Project Version:    %s\n", c.projectVersion)
-	fmt.Printf("Source:             %s\n", c.source)
+	fmt.Printf("Description:    %s\n", c.description)
+	fmt.Printf("Git Commit:     %s\n", c.gitCommit)
+	fmt.Printf("Go Version:     %s\n", runtime.Version())
+	fmt.Printf("Name:           %s\n", c.name)
+	fmt.Printf("OS / Arch:      %s / %s\n", runtime.GOOS, runtime.GOARCH)
+	fmt.Printf("Source:         %s\n", c.source)
 }

--- a/vendor/github.com/giantswarm/microkit/glide.lock
+++ b/vendor/github.com/giantswarm/microkit/glide.lock
@@ -1,10 +1,16 @@
-hash: 99739322efed130500891098e79780839fbb4f56466701e89a681a158fa7a871
-updated: 2016-12-15T14:34:55.737142201+01:00
+hash: 7543d77ca0168ce51ff499acd07d597874fd2f539bc20d4e3018a49bac01f117
+updated: 2016-12-19T17:22:28.447738107+01:00
 imports:
 - name: github.com/beorn7/perks
   version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
   subpackages:
   - quantile
+- name: github.com/coreos/etcd
+  version: 3d5ba43211beec7fbb1472634a9c3b464581658a
+  subpackages:
+  - client
+  - pkg/pathutil
+  - pkg/types
 - name: github.com/fsnotify/fsnotify
   version: fd9ec7deca8bf46ecd2a795baaacf2b3a9be1197
 - name: github.com/go-kit/kit
@@ -26,7 +32,7 @@ imports:
 - name: github.com/gorilla/mux
   version: 0eeaf8392f5b04950925b8a69fe70f110fa7cbfc
 - name: github.com/hashicorp/hcl
-  version: 37ab263305aaeb501a60eb16863e808d426e37f2
+  version: 80e628d796135357b3d2e33a985c666b9f35eee1
   subpackages:
   - hcl/ast
   - hcl/parser
@@ -87,6 +93,10 @@ imports:
   version: 5ed0fc31f7f453625df314d8e66b9791e8d13003
 - name: github.com/tylerb/graceful
   version: 50a48b6e73fcc75b45e22c05b79629a67c79e938
+- name: github.com/ugorji/go
+  version: f1f1a805ed361a0e078bb537e4ea78cd37dcf065
+  subpackages:
+  - codec
 - name: golang.org/x/net
   version: e90d6d0afc4c315a0d87a568ae68577cc15149a0
   subpackages:

--- a/vendor/github.com/giantswarm/microkit/glide.yaml
+++ b/vendor/github.com/giantswarm/microkit/glide.yaml
@@ -24,3 +24,7 @@ import:
   - context
 - package: github.com/go-stack/stack
   version: ~1.5.2
+- package: github.com/coreos/etcd
+  version: ~3.1.0-rc.1
+  subpackages:
+  - client

--- a/vendor/github.com/giantswarm/microkit/storage/error.go
+++ b/vendor/github.com/giantswarm/microkit/storage/error.go
@@ -1,0 +1,25 @@
+package storage
+
+import (
+	"github.com/juju/errgo"
+
+	"github.com/giantswarm/microkit/storage/etcd"
+	"github.com/giantswarm/microkit/storage/memory"
+)
+
+var invalidConfigError = errgo.New("invalid config")
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return errgo.Cause(err) == invalidConfigError
+}
+
+// IsKeyNotFound represents the error matcher for public use. Services using the
+// storage service internally should use this public key matcher to verify if
+// some storage error is of type "key not found", instead of using a specific
+// error matching of some specific storage implementation. This public error
+// matcher groups all necessary error matchers of more specific storage
+// implementations.
+func IsKeyNotFound(err error) bool {
+	return etcd.IsKeyNotFound(err) || memory.IsKeyNotFound(err)
+}

--- a/vendor/github.com/giantswarm/microkit/storage/etcd/error.go
+++ b/vendor/github.com/giantswarm/microkit/storage/etcd/error.go
@@ -1,0 +1,19 @@
+package etcd
+
+import (
+	"github.com/juju/errgo"
+)
+
+var invalidConfigError = errgo.New("invalid config")
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return errgo.Cause(err) == invalidConfigError
+}
+
+var keyNotFoundError = errgo.New("key not found")
+
+// IsKeyNotFound asserts keyNotFoundError.
+func IsKeyNotFound(err error) bool {
+	return errgo.Cause(err) == keyNotFoundError
+}

--- a/vendor/github.com/giantswarm/microkit/storage/etcd/service.go
+++ b/vendor/github.com/giantswarm/microkit/storage/etcd/service.go
@@ -1,0 +1,109 @@
+// Package etcd provides a service that implements an etcd storage.
+package etcd
+
+import (
+	"github.com/coreos/etcd/client"
+	"golang.org/x/net/context"
+
+	microerror "github.com/giantswarm/microkit/error"
+)
+
+// Config represents the configuration used to create a etcd service.
+type Config struct {
+	// Dependencies.
+	EtcdClient client.Client
+}
+
+// DefaultConfig provides a default configuration to create a new etcd service
+// by best effort.
+func DefaultConfig() Config {
+	etcdConfig := client.Config{
+		Endpoints: []string{"http://127.0.0.1:2379"},
+		Transport: client.DefaultTransport,
+	}
+	etcdClient, err := client.New(etcdConfig)
+	if err != nil {
+		panic(err)
+	}
+
+	return Config{
+		// Dependencies.
+		EtcdClient: etcdClient,
+	}
+}
+
+// New creates a new configured etcd service.
+func New(config Config) (*Service, error) {
+	// Dependencies.
+	if config.EtcdClient == nil {
+		return nil, microerror.MaskAnyf(invalidConfigError, "etcd client must not be empty")
+	}
+
+	newService := &Service{
+		// Dependencies.
+		etcdClient: config.EtcdClient,
+
+		// Internals.
+		keyClient: client.NewKeysAPI(config.EtcdClient),
+	}
+
+	return newService, nil
+}
+
+// Service is the etcd service.
+type Service struct {
+	// Dependencies.
+	etcdClient client.Client
+
+	// Internals.
+	keyClient client.KeysAPI
+}
+
+func (s *Service) Create(key, value string) error {
+	_, err := s.keyClient.Create(context.TODO(), key, value)
+	if err != nil {
+		return microerror.MaskAny(err)
+	}
+
+	return nil
+}
+
+func (s *Service) Delete(key string) error {
+	options := &client.DeleteOptions{
+		Recursive: true,
+	}
+	_, err := s.keyClient.Delete(context.TODO(), key, options)
+	if err != nil {
+		return microerror.MaskAny(err)
+	}
+
+	return nil
+}
+
+func (s *Service) Exists(key string) (bool, error) {
+	options := &client.GetOptions{
+		Quorum: true,
+	}
+	_, err := s.keyClient.Get(context.TODO(), key, options)
+	if client.IsKeyNotFound(err) {
+		return false, nil
+	} else if err != nil {
+		return false, microerror.MaskAny(err)
+	}
+
+	return true, nil
+}
+
+func (s *Service) Search(key string) (string, error) {
+	options := &client.GetOptions{
+		Quorum: true,
+	}
+	clientResponse, err := s.keyClient.Get(context.TODO(), key, options)
+	if client.IsKeyNotFound(err) {
+		return "", microerror.MaskAnyf(keyNotFoundError, key)
+	} else if err != nil {
+		return "", microerror.MaskAny(err)
+	}
+
+	return clientResponse.Node.Value, nil
+}

--- a/vendor/github.com/giantswarm/microkit/storage/memory/error.go
+++ b/vendor/github.com/giantswarm/microkit/storage/memory/error.go
@@ -1,0 +1,11 @@
+package memory
+
+import (
+	"github.com/juju/errgo"
+)
+
+var keyNotFoundError = errgo.New("key not found")
+
+func IsKeyNotFound(err error) bool {
+	return errgo.Cause(err) == keyNotFoundError
+}

--- a/vendor/github.com/giantswarm/microkit/storage/memory/service.go
+++ b/vendor/github.com/giantswarm/microkit/storage/memory/service.go
@@ -1,0 +1,74 @@
+// Package memory provides a service that implements a memory storage.
+package memory
+
+import (
+	"sync"
+
+	microerror "github.com/giantswarm/microkit/error"
+)
+
+// Config represents the configuration used to create a memory service.
+type Config struct {
+}
+
+// DefaultConfig provides a default configuration to create a new memory
+// service by best effort.
+func DefaultConfig() Config {
+	return Config{}
+}
+
+// New creates a new configured memory service.
+func New(config Config) (*Service, error) {
+	newService := &Service{
+		storage: map[string]string{},
+		mutex:   sync.Mutex{},
+	}
+
+	return newService, nil
+}
+
+// Service is the memory service.
+type Service struct {
+	// Internals.
+	storage map[string]string
+	mutex   sync.Mutex
+}
+
+func (s *Service) Create(key, value string) error {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	s.storage[key] = value
+
+	return nil
+}
+
+func (s *Service) Delete(key string) error {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	delete(s.storage, key)
+
+	return nil
+}
+
+func (s *Service) Exists(key string) (bool, error) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	_, ok := s.storage[key]
+
+	return ok, nil
+}
+
+func (s *Service) Search(key string) (string, error) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	value, ok := s.storage[key]
+	if ok {
+		return value, nil
+	}
+
+	return "", microerror.MaskAnyf(keyNotFoundError, key)
+}

--- a/vendor/github.com/giantswarm/microkit/storage/memory/service_test.go
+++ b/vendor/github.com/giantswarm/microkit/storage/memory/service_test.go
@@ -1,0 +1,65 @@
+package memory
+
+import (
+	"testing"
+)
+
+func Test_Service(t *testing.T) {
+	newStorage, err := New(DefaultConfig())
+	if err != nil {
+		t.Fatal("expected", nil, "got", err)
+	}
+
+	key := "test-key"
+	value := "test-value"
+
+	ok, err := newStorage.Exists(key)
+	if err != nil {
+		t.Fatal("expected", nil, "got", err)
+	}
+	if ok {
+		t.Fatal("expected", false, "got", true)
+	}
+
+	err = newStorage.Create(key, value)
+	if err != nil {
+		t.Fatal("expected", nil, "got", err)
+	}
+
+	ok, err = newStorage.Exists(key)
+	if err != nil {
+		t.Fatal("expected", nil, "got", err)
+	}
+	if !ok {
+		t.Fatal("expected", true, "got", false)
+	}
+
+	v, err := newStorage.Search(key)
+	if err != nil {
+		t.Fatal("expected", nil, "got", err)
+	}
+	if v != value {
+		t.Fatal("expected", value, "got", v)
+	}
+
+	err = newStorage.Delete(key)
+	if err != nil {
+		t.Fatal("expected", nil, "got", err)
+	}
+
+	ok, err = newStorage.Exists(key)
+	if err != nil {
+		t.Fatal("expected", nil, "got", err)
+	}
+	if ok {
+		t.Fatal("expected", false, "got", true)
+	}
+
+	v, err = newStorage.Search(key)
+	if !IsKeyNotFound(err) {
+		t.Fatal("expected", true, "got", false)
+	}
+	if v != "" {
+		t.Fatal("expected", "empty string", "got", v)
+	}
+}

--- a/vendor/github.com/giantswarm/microkit/storage/spec.go
+++ b/vendor/github.com/giantswarm/microkit/storage/spec.go
@@ -1,0 +1,20 @@
+package storage
+
+// Service represents the abstraction for underlying storage backends. A storage
+// service implementation does not care about specific data types. All the
+// storage cares about are key-value pairs. Services making use of the storage
+// have to take care about specific types they care about them self.
+type Service interface {
+	// Create stores the given value under the given key. Keys and values might
+	// have specific schemes depending on the specific storage implementation.
+	// E.g. an etcd storage implementation will allow keys to be defined as paths:
+	// path/to/key. Values might be JSON strings in case the service using the
+	// storage wants to store its data as JSON strings.
+	Create(key, value string) error
+	// Delete removes the value stored under the given key.
+	Delete(key string) error
+	// Exists checks if a value under the given key exists or not.
+	Exists(key string) (bool, error)
+	// Search does a lookup for the value stored under key and returns it, if any.
+	Search(key string) (string, error)
+}

--- a/vendor/github.com/giantswarm/microkit/storage/storage.go
+++ b/vendor/github.com/giantswarm/microkit/storage/storage.go
@@ -1,0 +1,82 @@
+// Package storage provides interface and error specifications. The storage sub
+// packages provide specific storage implementations.
+package storage
+
+import (
+	"github.com/coreos/etcd/client"
+
+	microerror "github.com/giantswarm/microkit/error"
+	"github.com/giantswarm/microkit/storage/etcd"
+	"github.com/giantswarm/microkit/storage/memory"
+)
+
+const (
+	// KindMemory is the kind to be used to create a memory storage service.
+	KindMemory = "memory"
+	// KindEtcd is the kind to be used to create an etcd storage service.
+	KindEtcd = "etcd"
+)
+
+// Config represents the configuration used to create a storage service.
+type Config struct {
+	// Settings.
+	EtcdAddress string
+	Kind        string
+}
+
+// DefaultConfig provides a default configuration to create a new storage
+// service by best effort.
+func DefaultConfig() Config {
+	return Config{
+		// Settings.
+		EtcdAddress: "",
+		Kind:        "",
+	}
+}
+
+// New creates a new configured storage service.
+func New(config Config) (Service, error) {
+	// Settings.
+	if config.Kind == "" {
+		return nil, microerror.MaskAnyf(invalidConfigError, "kind must not be empty")
+	}
+	if config.Kind != KindMemory && config.Kind != KindEtcd {
+		return nil, microerror.MaskAnyf(invalidConfigError, "kind must be one of: %s, %s", KindMemory, KindEtcd)
+	}
+
+	var err error
+
+	var storageService Service
+	{
+		switch config.Kind {
+		case KindMemory:
+			storageConfig := memory.DefaultConfig()
+			storageService, err = memory.New(storageConfig)
+			if err != nil {
+				return nil, microerror.MaskAny(err)
+			}
+		case KindEtcd:
+			if config.EtcdAddress == "" {
+				return nil, microerror.MaskAnyf(invalidConfigError, "etcd address must not be empty")
+			}
+
+			etcdConfig := client.Config{
+				Endpoints: []string{config.EtcdAddress},
+				Transport: client.DefaultTransport,
+			}
+			etcdClient, err := client.New(etcdConfig)
+			if err != nil {
+				return nil, microerror.MaskAny(err)
+			}
+
+			storageConfig := etcd.DefaultConfig()
+			storageConfig.EtcdClient = etcdClient
+			storageService, err = etcd.New(storageConfig)
+			if err != nil {
+				return nil, microerror.MaskAny(err)
+			}
+		}
+	}
+
+	return storageService, nil
+}

--- a/vendor/github.com/prometheus/common/model/metric.go
+++ b/vendor/github.com/prometheus/common/model/metric.go
@@ -44,7 +44,7 @@ func (m Metric) Before(o Metric) bool {
 
 // Clone returns a copy of the Metric.
 func (m Metric) Clone() Metric {
-	clone := Metric{}
+	clone := make(Metric, len(m))
 	for k, v := range m {
 		clone[k] = v
 	}

--- a/vendor/github.com/spf13/pflag/.travis.yml
+++ b/vendor/github.com/spf13/pflag/.travis.yml
@@ -3,9 +3,8 @@ sudo: false
 language: go
 
 go:
-        - 1.5.4
         - 1.6.3
-        - 1.7
+        - 1.7.3
         - tip
 
 matrix:

--- a/vendor/github.com/spf13/pflag/bool_test.go
+++ b/vendor/github.com/spf13/pflag/bool_test.go
@@ -6,7 +6,6 @@ package pflag
 
 import (
 	"bytes"
-	"fmt"
 	"strconv"
 	"testing"
 )
@@ -48,7 +47,7 @@ func (v *triStateValue) String() string {
 	if *v == triStateMaybe {
 		return strTriStateMaybe
 	}
-	return fmt.Sprintf("%v", bool(*v == triStateTrue))
+	return strconv.FormatBool(*v == triStateTrue)
 }
 
 // The type of the flag as required by the pflag.Value interface

--- a/vendor/github.com/spf13/pflag/count_test.go
+++ b/vendor/github.com/spf13/pflag/count_test.go
@@ -1,12 +1,9 @@
 package pflag
 
 import (
-	"fmt"
 	"os"
 	"testing"
 )
-
-var _ = fmt.Printf
 
 func setUpCount(c *int) *FlagSet {
 	f := NewFlagSet("test", ContinueOnError)

--- a/vendor/github.com/spf13/pflag/flag.go
+++ b/vendor/github.com/spf13/pflag/flag.go
@@ -416,7 +416,7 @@ func Set(name, value string) error {
 // otherwise, the default values of all defined flags in the set.
 func (f *FlagSet) PrintDefaults() {
 	usages := f.FlagUsages()
-	fmt.Fprintf(f.out(), "%s", usages)
+	fmt.Fprint(f.out(), usages)
 }
 
 // defaultIsZeroValue returns true if the default value for this flag represents
@@ -514,7 +514,7 @@ func (f *FlagSet) FlagUsages() string {
 		if len(flag.NoOptDefVal) > 0 {
 			switch flag.Value.Type() {
 			case "string":
-				line += fmt.Sprintf("[=%q]", flag.NoOptDefVal)
+				line += fmt.Sprintf("[=\"%s\"]", flag.NoOptDefVal)
 			case "bool":
 				if flag.NoOptDefVal != "true" {
 					line += fmt.Sprintf("[=%s]", flag.NoOptDefVal)
@@ -534,7 +534,7 @@ func (f *FlagSet) FlagUsages() string {
 		line += usage
 		if !flag.defaultIsZeroValue() {
 			if flag.Value.Type() == "string" {
-				line += fmt.Sprintf(" (default %q)", flag.DefValue)
+				line += fmt.Sprintf(" (default \"%s\")", flag.DefValue)
 			} else {
 				line += fmt.Sprintf(" (default %s)", flag.DefValue)
 			}

--- a/vendor/github.com/spf13/pflag/string_array.go
+++ b/vendor/github.com/spf13/pflag/string_array.go
@@ -2,7 +2,6 @@ package pflag
 
 import (
 	"fmt"
-	"strings"
 )
 
 var _ = fmt.Fprint
@@ -40,7 +39,7 @@ func (s *stringArrayValue) String() string {
 }
 
 func stringArrayConv(sval string) (interface{}, error) {
-	sval = strings.Trim(sval, "[]")
+	sval = sval[1 : len(sval)-1]
 	// An empty string would cause a array with one (empty) string
 	if len(sval) == 0 {
 		return []string{}, nil

--- a/vendor/github.com/spf13/pflag/string_array_test.go
+++ b/vendor/github.com/spf13/pflag/string_array_test.go
@@ -192,3 +192,42 @@ func TestSAWithSpecialChar(t *testing.T) {
 		}
 	}
 }
+
+func TestSAWithSquareBrackets(t *testing.T) {
+	var sa []string
+	f := setUpSAFlagSet(&sa)
+
+	in := []string{"][]-[", "[a-z]", "[a-z]+"}
+	expected := []string{"][]-[", "[a-z]", "[a-z]+"}
+	argfmt := "--sa=%s"
+	arg1 := fmt.Sprintf(argfmt, in[0])
+	arg2 := fmt.Sprintf(argfmt, in[1])
+	arg3 := fmt.Sprintf(argfmt, in[2])
+	err := f.Parse([]string{arg1, arg2, arg3})
+	if err != nil {
+		t.Fatal("expected no error; got", err)
+	}
+
+	if len(expected) != len(sa) {
+		t.Fatalf("expected number of sa to be %d but got: %d", len(expected), len(sa))
+	}
+	for i, v := range sa {
+		if expected[i] != v {
+			t.Fatalf("expected sa[%d] to be %s but got: %s", i, expected[i], v)
+		}
+	}
+
+	values, err := f.GetStringArray("sa")
+	if err != nil {
+		t.Fatal("expected no error; got", err)
+	}
+
+	if len(expected) != len(values) {
+		t.Fatalf("expected number of values to be %d but got: %d", len(expected), len(values))
+	}
+	for i, v := range values {
+		if expected[i] != v {
+			t.Fatalf("expected got sa[%d] to be %s but got: %s", i, expected[i], v)
+		}
+	}
+}

--- a/vendor/github.com/spf13/pflag/string_slice.go
+++ b/vendor/github.com/spf13/pflag/string_slice.go
@@ -66,7 +66,7 @@ func (s *stringSliceValue) String() string {
 }
 
 func stringSliceConv(sval string) (interface{}, error) {
-	sval = strings.Trim(sval, "[]")
+	sval = sval[1 : len(sval)-1]
 	// An empty string would cause a slice with one (empty) string
 	if len(sval) == 0 {
 		return []string{}, nil

--- a/vendor/github.com/spf13/pflag/string_slice_test.go
+++ b/vendor/github.com/spf13/pflag/string_slice_test.go
@@ -213,3 +213,41 @@ func TestSSWithComma(t *testing.T) {
 		}
 	}
 }
+
+func TestSSWithSquareBrackets(t *testing.T) {
+	var ss []string
+	f := setUpSSFlagSet(&ss)
+
+	in := []string{`"[a-z]"`, `"[a-z]+"`}
+	expected := []string{"[a-z]", "[a-z]+"}
+	argfmt := "--ss=%s"
+	arg1 := fmt.Sprintf(argfmt, in[0])
+	arg2 := fmt.Sprintf(argfmt, in[1])
+	err := f.Parse([]string{arg1, arg2})
+	if err != nil {
+		t.Fatal("expected no error; got", err)
+	}
+
+	if len(expected) != len(ss) {
+		t.Fatalf("expected number of ss to be %d but got: %d", len(expected), len(ss))
+	}
+	for i, v := range ss {
+		if expected[i] != v {
+			t.Fatalf("expected ss[%d] to be %s but got: %s", i, expected[i], v)
+		}
+	}
+
+	values, err := f.GetStringSlice("ss")
+	if err != nil {
+		t.Fatal("expected no error; got", err)
+	}
+
+	if len(expected) != len(values) {
+		t.Fatalf("expected number of values to be %d but got: %d", len(expected), len(values))
+	}
+	for i, v := range values {
+		if expected[i] != v {
+			t.Fatalf("expected got ss[%d] to be %s but got: %s", i, expected[i], v)
+		}
+	}
+}


### PR DESCRIPTION
This PR removes support for the semver project version. The guideline is to apply semver versioning on libraries, not on deployable microservices. We want establish to automatically move forward using CI/CD. Semver versioning has to be applied to packages and APIs, if any.

RFR @giantswarm/team-positive